### PR TITLE
feat: Use rectangle and text + other IE fixes

### DIFF
--- a/src/tree/render.js
+++ b/src/tree/render.js
@@ -39,17 +39,17 @@ const reRenderTree = ({ svg, activeNode, allNodes, o, width, height }) => {
   // Cleanup from previous render
   if (previousNodes.length > 0 && activeNodes._groups[0].length > 0) {
     let removeList = [];
-    for (const node of previousNodes) {
+    previousNodes.forEach(node => {
       if (nodeIdList.indexOf(node.data.id) === -1) {
         removeList.push(node.data.id);
       }
-    }
+    });
     const previousNodesIdList = previousNodes.map(node => node.data.id);
-    for (const node of nodes) {
+    nodes.forEach(node => {
       if (previousNodesIdList.indexOf(node.data.id) === -1) {
         appendNodes.push(node);
       }
-    }
+    });
     if (removeList.length > 0) {
       svg
         .selectAll('g')
@@ -90,8 +90,7 @@ const reRenderTree = ({ svg, activeNode, allNodes, o, width, height }) => {
         reRenderTree({ svg, allNodes, o, activeNode: node.data.id, width, height });
       }
     })
-
-    function wrap() {
+    function ellipsis() {
       var self = select(this),
           textLength = self.node().getComputedTextLength(),
           text = self.text();
@@ -101,19 +100,29 @@ const reRenderTree = ({ svg, activeNode, allNodes, o, width, height }) => {
           textLength = self.node().getComputedTextLength();
       }
     }
+
+    function shrink() {
+      var self = select(this),
+          textLength = self.node().getComputedTextLength();
+      while (textLength > 300) {
+          const currentSize = self.style('font-size').slice(0, -2)
+          self.style('font-size', `${currentSize - 2}px`);
+          textLength = self.node().getComputedTextLength();
+      }
+    }
   node.append('text')
     .text(d => d.data.name)
     .attr('x', o.x)
     .attr('y', o.yText)
     .attr('fill', 'black')
     .attr('class', 'orgText')
-    .each(wrap)
+    // .style('font-size', '40px')
+    .each(ellipsis)
     .on('click', node => {
       if (node.children) {
         reRenderTree({ svg, allNodes, o, activeNode: node.data.id, width, height });
       }
     })
-
 
   // Create the div element for the nodes
   // node
@@ -164,7 +173,10 @@ const reRenderTree = ({ svg, activeNode, allNodes, o, width, height }) => {
     });
 
   // Zooming and positioning of the tree
-  const bBox = svg._groups[0][0].getBBox();
+  console.log(svg._groups[0][0]);
+  const bBox = svg._groups[0][0].getBBox(); // document.getElementsByClassName('topG')[0].getBoundingClientRect();
+
+  //TODO: make this based on height as well
   const xFactor = bBox.width / width;
   svg
     .transition()
@@ -218,7 +230,7 @@ const renderTree = async ({ element, layout, app, model }) => {
     .attr('width', width)
     .attr('height', height);
 
-  const svg = svgBox.append('g');
+  const svg = svgBox.append('g').attr('class', 'topG')
   svg.each(orientation => {
     const o = orientation.value;
     // Here are the settings for the tree. For instance nodesize can be adjusted

--- a/src/tree/render.js
+++ b/src/tree/render.js
@@ -85,7 +85,7 @@ const reRenderTree = ({ svg, activeNode, allNodes, o, width, height }) => {
     .attr('height', 100)
     .attr('x', o.x)
     .attr('y', o.y)
-    .style('fill', 'white')
+    .style('fill', 'pink')
     .attr('stroke', 'black')
     .on('click', node => {
       if (node.children) {
@@ -151,6 +151,7 @@ const reRenderTree = ({ svg, activeNode, allNodes, o, width, height }) => {
     .attr('class', 'link')
     .attr('id', d => d.data.id)
     .attr('d', function(d) {
+
       const self = { x: o.x(d) + halfNodeWidth, y: o.y(d) };
       if (d.parent) {
         const parent = { x: o.x(d.parent) + halfNodeWidth, y: o.y(d.parent) + nodeSize.height };
@@ -176,7 +177,7 @@ const reRenderTree = ({ svg, activeNode, allNodes, o, width, height }) => {
     });
 
   // Zooming and positioning of the tree
-  const bBox = svg._groups[0][0].getBBox(); // document.getElementsByClassName('topG')[0].getBoundingClientRect();
+  const bBox = svg._groups[0][0].getBBox();
 
   //TODO: make this based on height as well
   const xFactor = bBox.width / width;
@@ -211,13 +212,6 @@ const renderTree = async ({ element, layout, app, model }) => {
       y: function(d) {
         return d.y;
       },
-
-      yText: function(d) {
-        return d.y + 50;
-      },
-      yLine: function(d) {
-        return d.depth * 150 + 75;
-      },
     },
   };
 
@@ -232,7 +226,7 @@ const renderTree = async ({ element, layout, app, model }) => {
     .attr('width', width)
     .attr('height', height);
 
-  const svg = svgBox.append('g').attr('class', 'topG')
+  const svg = svgBox.append('g');
   svg.each(orientation => {
     const o = orientation.value;
     // Here are the settings for the tree. For instance nodesize can be adjusted

--- a/src/tree/render.js
+++ b/src/tree/render.js
@@ -78,23 +78,60 @@ const reRenderTree = ({ svg, activeNode, allNodes, o, width, height }) => {
     .attr('class', 'nodeWrapper')
     .attr('id', d => d.data.id);
 
-  // Create the div element for the nodes
-  node
-    .append('foreignObject')
-    .attr('class', 'nodeRect')
-    .attr('width', nodeSize.width)
-    .attr('height', nodeSize.height)
+    node.append('rect')
+    .attr('width', 300)
+    .attr('height', 100)
     .attr('x', o.x)
     .attr('y', o.y)
-    .attr('id', d => d.data.id)
+    .style('fill', 'white')
+    .attr('stroke', 'black')
     .on('click', node => {
       if (node.children) {
         reRenderTree({ svg, allNodes, o, activeNode: node.data.id, width, height });
       }
     })
-    .html(d => {
-      return card(d.data);
-    });
+
+    function wrap() {
+      var self = select(this),
+          textLength = self.node().getComputedTextLength(),
+          text = self.text();
+      while (textLength > 300) {
+          text = text.slice(0, -1);
+          self.text(text + '...');
+          textLength = self.node().getComputedTextLength();
+      }
+    }
+  node.append('text')
+    .text(d => d.data.name)
+    .attr('x', o.x)
+    .attr('y', o.yText)
+    .attr('fill', 'black')
+    .attr('class', 'orgText')
+    .each(wrap)
+    .on('click', node => {
+      if (node.children) {
+        reRenderTree({ svg, allNodes, o, activeNode: node.data.id, width, height });
+      }
+    })
+
+
+  // Create the div element for the nodes
+  // node
+  //   .append('foreignObject')
+  //   .attr('class', 'nodeRect')
+  //   .attr('width', 300)
+  //   .attr('height', 100)
+  //   .attr('x', o.x)
+  //   .attr('y', o.y)
+  //   .attr('id', d => d.data.id)
+  //   .on('click', node => {
+  //     if (node.children) {
+  //       reRenderTree({ svg, allNodes, o, activeNode: node.data.id, width, height });
+  //     }
+  //   })
+  //   .html(d => {
+  //     return card(d.data);
+  //   });
 
   // Create the lines (links) between the nodes
   node
@@ -159,6 +196,13 @@ const renderTree = async ({ element, layout, app, model }) => {
       },
       y: function(d) {
         return d.y;
+      },
+
+      yText: function(d) {
+        return d.y + 50;
+      },
+      yLine: function(d) {
+        return d.depth * 150 + 75;
       },
     },
   };

--- a/src/treeCss.css
+++ b/src/treeCss.css
@@ -35,7 +35,13 @@ body {
 
 .orgCard {
   background: pink;
+  color: black;
   width: 100%;
   height: 100%;
+  font-size: 40px;
+}
+
+.orgText {
+  color: black;
   font-size: 40px;
 }

--- a/src/treeCss.css
+++ b/src/treeCss.css
@@ -35,7 +35,6 @@ body {
 
 .orgCard {
   background: pink;
-  color: black;
   width: 100%;
   height: 100%;
   font-size: 40px;


### PR DESCRIPTION
Using the rectangle and text elements instead of foreignObject. Text manipulation needs to be done very manually, but totally doable. Managed to get ellipsis, shrinking text and wrapping to work in order to fit text inside the rectangle. I'm guessing UX wants wrapping but we know all three are possible.

Other text styling should be doable in a similar fasion as we styled the action button.