### PR TITLE
fix: disable transitions in ie11

### DIFF
--- a/src/tree/render.js
+++ b/src/tree/render.js
@@ -5,6 +5,7 @@ import box from './box';
 import path from './path';
 import '../treeCss.css';
 import stylingUtils from '../utils/styling';
+import transform from './transform';
 
 // Constants for the tree. Might be variables later in property panel
 const nodeSize = { width: 300, height: 100 };
@@ -28,27 +29,6 @@ const filterTree = (id, nodeTree) => {
       (node.parent && node.parent.data.id === currentNode.data.id)
     );
   });
-};
-
-const getBBoxOfNodes = nodes => {
-  const bbox = {
-    left: Infinity,
-    top: Infinity,
-    right: -Infinity,
-    bottom: -Infinity,
-  };
-  nodes.forEach(node => {
-    bbox.left = Math.min(node.xActual, bbox.left);
-    bbox.top = Math.min(node.yActual, bbox.top);
-    bbox.right = Math.max(node.xActual, bbox.right);
-    bbox.bottom = Math.max(node.yActual, bbox.bottom);
-  });
-  return {
-    x: bbox.left,
-    y: bbox.top,
-    width: bbox.right - bbox.left + nodeSize.width,
-    height: bbox.bottom - bbox.top + nodeSize.height,
-  };
 };
 
 const reRenderTree = ({ svg, divBox, activeNode, allNodes, o, width, height, cardStyling }) => {
@@ -121,24 +101,7 @@ const reRenderTree = ({ svg, divBox, activeNode, allNodes, o, width, height, car
   // Create the lines (links) between the nodes
   path(node, o, isVertical);
 
-  // Zooming and positioning of the tree
-  const bBox = getBBoxOfNodes(nodes);
-  const scaleToWidhth = bBox.width / width > bBox.height / height;
-  const scaleFactor = scaleToWidhth ? bBox.width / width : bBox.height / height;
-  const translation = scaleToWidhth
-    ? `${-bBox.x}px, ${-bBox.y + (height * scaleFactor - bBox.height) / 2}px`
-    : `${-bBox.x + (width * scaleFactor - bBox.width) / 2}px, ${-bBox.y}px`;
-  /* svg
-    .transition()
-    .duration(transitionTime)
-    .attr('transform', `scale(${1 / scaleFactor}) translate(${translation})`);
-*/
-  svg.attr('style', `transform: scale(${1 / scaleFactor}) translate(${translation});`);
-  divBox.attr(
-    'style',
-    // eslint-disable-next-line comma-dangle
-    `width:${width}px;height:${height}px; transform: scale(${1 / scaleFactor}) translate(${translation});`
-  );
+  transform(nodes, nodeSize, width, height, svg, divBox);
 };
 
 const renderTree = async ({ element, layout, model, Theme }) => {

--- a/src/tree/transform.js
+++ b/src/tree/transform.js
@@ -1,0 +1,53 @@
+const getBBoxOfNodes = (nodes, nodeSize) => {
+  const bbox = {
+    left: Infinity,
+    top: Infinity,
+    right: -Infinity,
+    bottom: -Infinity,
+  };
+  nodes.forEach(node => {
+    bbox.left = Math.min(node.xActual, bbox.left);
+    bbox.top = Math.min(node.yActual, bbox.top);
+    bbox.right = Math.max(node.xActual, bbox.right);
+    bbox.bottom = Math.max(node.yActual, bbox.bottom);
+  });
+  return {
+    x: bbox.left,
+    y: bbox.top,
+    width: bbox.right - bbox.left + nodeSize.width,
+    height: bbox.bottom - bbox.top + nodeSize.height,
+  };
+};
+
+export default function transform(nodes, nodeSize, width, height, svg, divBox) {
+  // Zooming and positioning of the tree
+  const bBox = getBBoxOfNodes(nodes, nodeSize);
+  const scaleToWidhth = bBox.width / width > bBox.height / height;
+  const scaleFactor = scaleToWidhth ? bBox.width / width : bBox.height / height;
+  const translation = scaleToWidhth
+    ? `${-bBox.x}px, ${-bBox.y + (height * scaleFactor - bBox.height) / 2}px`
+    : `${-bBox.x + (width * scaleFactor - bBox.width) / 2}px, ${-bBox.y}px`;
+
+  const svgTranslate = scaleToWidhth
+    ? `${-bBox.x} ${-bBox.y + (height * scaleFactor - bBox.height) / 2}`
+    : `${-bBox.x + (width * scaleFactor - bBox.width) / 2} ${-bBox.y}`;
+
+  const isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
+  if (isIE11) {
+    // Transition using d3 + svg transform, for IE11
+    svg.attr('transform', `scale(${1 / scaleFactor}) translate(${svgTranslate})`);
+    divBox.classed('org-disable-transition', true);
+    svg.classed('org-disable-transition', true);
+  } else {
+    // Transition using css, does not work in IE11
+    svg.attr('style', `transform: scale(${1 / scaleFactor}) translate(${translation});`);
+    divBox.classed('org-disable-transition', false);
+    svg.classed('org-disable-transition', false);
+  }
+
+  divBox.attr(
+    'style',
+    `width:${width}px;height:${height}px;
+  transform: scale(${1 / scaleFactor}) translate(${translation});`
+  );
+}

--- a/src/treeCss.css
+++ b/src/treeCss.css
@@ -43,7 +43,8 @@
   text-overflow: ellipsis;
 }
 
-.org-path-holder {
+/* For css only transitions, does not work in IE11 */
+.org-path-holder:not(.org-disable-transition) {
   transform-origin: 0% 0%;
   transition-property: all;
   transition-duration: 0.5s;
@@ -52,6 +53,9 @@
 .org-node-holder {
   position: absolute;
   transform-origin: 0% 0%;
+}
+
+.org-node-holder:not(.org-disable-transition) {
   transition-property: all;
   transition-duration: 0.5s;
 }


### PR DESCRIPTION
Turns out the transitions in ie11 is quite hard to fix, and it would make it worse in other browsers. My current thought is to just check for ie11 and disable those transitions. Basically not spend more time on it.