### PR TITLE
feat: added zoom and pan for viewstate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,6 +185,7 @@ export default function supernova(env) {
             selectionsAndTransform,
             selectionState,
             useTransitions: expandedState.useTransitions,
+            element,
           });
         }
       }, [expandedState, objectData, selectionState]);

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ export default function supernova(env) {
       const [opts] = useState(options);
       const selectionsAPI = useSelections();
       const constraints = useConstraints();
-      const [selections] = useState({ api: selectionsAPI, setState: setSelectionState, linked: false });
+      const [selections] = useState({ api: selectionsAPI, setState: setSelectionState, linked: false, constraints });
 
       const resetSelections = () => {
         setSelectionState([]);
@@ -111,6 +111,10 @@ export default function supernova(env) {
         setExpandedState(newState);
       };
 
+      useEffect(() => {
+        selections.constraints = constraints;
+      }, [constraints]);
+
       /*
        * Basic steps to aim for - function [dependency]
        * - createElements [element]
@@ -152,7 +156,7 @@ export default function supernova(env) {
               });
           }
         }
-      }, [element, dataTree, constraints]);
+      }, [element, dataTree]);
 
       useEffect(() => {
         if (objectData && expandedState && styling) {
@@ -163,11 +167,10 @@ export default function supernova(env) {
             setStateCallback,
             selections,
             selectionState,
-            constraints,
             useTransitions: expandedState.useTransitions,
           });
         }
-      }, [expandedState, objectData, selectionState, constraints]);
+      }, [expandedState, objectData, selectionState]);
 
       useEffect(() => {
         if (objectData && layout.navigationMode === 'free') {
@@ -176,10 +179,10 @@ export default function supernova(env) {
             objectData,
             setTransform,
             transformState: (viewState && viewState.transform) || {},
-            allowInteractions: !constraints.active,
+            selections,
           });
         }
-      }, [objectData, constraints]);
+      }, [objectData]);
 
       const createViewState = () => {
         const vs = {

--- a/src/tree/box.js
+++ b/src/tree/box.js
@@ -67,7 +67,7 @@ export default function box(
   selectionState,
   selectionsAndTransform,
   navigationMode,
-  height
+  element
 ) {
   const {
     cardWidth,
@@ -98,7 +98,7 @@ export default function box(
   function getTooltipStyle(d) {
     const halfCardWidth = cardWidth / 2;
     const halfTooltipWidth = tooltipWidth / 2;
-    return `bottom:${height -
+    return `bottom:${element.clientHeight -
       (y(d) * selectionsAndTransform.transform.zoom + selectionsAndTransform.transform.y - tooltipPadding)}px;left:${x(
       d
     ) *

--- a/src/tree/box.js
+++ b/src/tree/box.js
@@ -65,7 +65,6 @@ export default function box(
   setStateCallback,
   selectionState,
   sel,
-  allowInteractions,
   navigationMode
 ) {
   const { cardWidth, cardHeight, buttonWidth, buttonHeight, buttonMargin, rootDiameter } = constants;
@@ -93,7 +92,7 @@ export default function box(
     .attr('style', d => `width:${cardWidth}px;height:${cardHeight}px; top:${y(d)}px;left:${x(d)}px;`)
     .attr('id', d => d.data.id)
     .on('click', node => {
-      if (allowInteractions && node.data.id !== 'Root') {
+      if (!sel.constraints.active && node.data.id !== 'Root') {
         selections.select(node, sel, selectionState);
       }
     })
@@ -114,7 +113,7 @@ export default function box(
     )
     .attr('id', d => `${d.data.id}-expand`)
     .on('click', d => {
-      if (allowInteractions) {
+      if (!sel.constraints.active) {
         setStateCallback(getNewState(d, expandedState, ancestorIds));
       }
     })
@@ -136,7 +135,7 @@ export default function box(
       )
       .attr('id', d => `${d.data.id}-up`)
       .on('click', d => {
-        if (allowInteractions) {
+        if (!sel.constraints.active) {
           setStateCallback(getNewUpState(d, isExpanded));
         }
       })

--- a/src/tree/render.js
+++ b/src/tree/render.js
@@ -40,7 +40,6 @@ export const paintTree = ({
   setStateCallback,
   selections,
   selectionState,
-  constraints,
   useTransitions,
 }) => {
   const { svg, divBox, allNodes, positioning, width, height } = objectData;
@@ -50,18 +49,7 @@ export const paintTree = ({
   // filter the nodes the nodes
   const nodes = filterTree(expandedState, allNodes);
   // Create cards and naviagation buttons
-  box(
-    positioning,
-    divBox,
-    nodes,
-    styling,
-    expandedState,
-    setStateCallback,
-    selectionState,
-    selections,
-    !constraints.active,
-    navigationMode
-  );
+  box(positioning, divBox, nodes, styling, expandedState, setStateCallback, selectionState, selections, navigationMode);
   // Create the lines (links) between the nodes
   const node = svg
     .selectAll('.sn-org-paths')

--- a/src/tree/render.js
+++ b/src/tree/render.js
@@ -41,6 +41,7 @@ export const paintTree = ({
   selectionsAndTransform,
   selectionState,
   useTransitions,
+  element,
 }) => {
   const { svg, divBox, allNodes, positioning, width, height, tooltip } = objectData;
   const { navigationMode } = allNodes.data;
@@ -60,7 +61,7 @@ export const paintTree = ({
     selectionState,
     selectionsAndTransform,
     navigationMode,
-    height
+    element
   );
   // Create the lines (links) between the nodes
   const node = svg

--- a/src/tree/transform.js
+++ b/src/tree/transform.js
@@ -37,7 +37,7 @@ export function applyTransform(eventTransform, svg, divBox, width, height) {
   );
 }
 
-export function setZooming({ objectData, setTransform, transformState, allowInteractions }) {
+export function setZooming({ objectData, setTransform, transformState, selections }) {
   const { svg, divBox, width, height, zoomWrapper, allNodes } = objectData;
   const { x = 0, y = 0 } = transformState;
   const maxZoom = 6;
@@ -62,7 +62,7 @@ export function setZooming({ objectData, setTransform, transformState, allowInte
         [0, 0],
         [width, height],
       ])
-      .filter(allowInteractions)
+      .filter(() => !selections.constraints.active)
       .scaleExtent([minZoom * scaleFactor, maxZoom * scaleFactor])
       .on('zoom', zoomed)
   );

--- a/src/tree/transform.js
+++ b/src/tree/transform.js
@@ -37,13 +37,16 @@ export function applyTransform(eventTransform, svg, divBox, width, height) {
   );
 }
 
-export function setZooming(objectData, allowInteractions) {
-  const { svg, divBox, width, height, allNodes, zoomWrapper } = objectData;
+export function setZooming({ objectData, setTransform, transformState, allowInteractions }) {
+  const { svg, divBox, width, height, zoomWrapper, allNodes } = objectData;
+  const { x = 0, y = 0 } = transformState;
   const maxZoom = 6;
   const minZoom = 0.2;
-  const scaleFactor = Math.max(Math.min(maxZoom, allNodes.zoomFactor), minZoom);
+  const zoomFactor = (transformState && transformState.zoom) || allNodes.zoomFactor;
+  const scaleFactor = Math.max(Math.min(maxZoom, zoomFactor), minZoom);
 
   const zoomed = () => {
+    setTransform({ zoom: scaleFactor / event.transform.k, x: event.transform.x, y: event.transform.y });
     applyTransform(
       zoomIdentity.translate(event.transform.x, event.transform.y).scale(event.transform.k / scaleFactor),
       svg,
@@ -64,7 +67,7 @@ export function setZooming(objectData, allowInteractions) {
       .on('zoom', zoomed)
   );
 
-  applyTransform(zoomIdentity.translate(0, 0).scale(1 / scaleFactor), svg, divBox, width, height);
+  applyTransform(zoomIdentity.translate(x, y).scale(1 / scaleFactor), svg, divBox, width, height);
 }
 
 export default function transform(nodes, width, height, svg, divBox, useTransitions) {


### PR DESCRIPTION
When switching between edit and analysis mode everything will re-render now. Tried to keep the state but that did not really work for zooming/panning. 

We might have another try later, but wanted to get the viewstate in for download/export at least

**EDIT: We do keep the zoom pan state between edit and analysis mode now**