### PR TITLE
fix: filter events for zoom

### DIFF
--- a/src/tree/transform.js
+++ b/src/tree/transform.js
@@ -43,6 +43,7 @@ export function setZooming(objectData, settingZoom, allowInteractions) {
   const minZoom = 0.2;
   const scaleFactor = Math.max(Math.min(maxZoom, allNodes.zoomFactor), minZoom);
 
+  // sends otherwise captured mouse event to handle context menu correctly in sense
   const bubbleEvent = () => {
     const newEvent = document.createEvent('MouseEvents');
     newEvent.initEvent('mousedown', true, false);

--- a/src/tree/transform.js
+++ b/src/tree/transform.js
@@ -38,12 +38,19 @@ export function applyTransform(eventTransform, svg, divBox, width, height) {
 }
 
 export function setZooming(objectData, settingZoom, allowInteractions) {
-  const { svg, divBox, width, height, allNodes, zoomWrapper } = objectData;
+  const { svg, divBox, width, height, allNodes, zoomWrapper, element } = objectData;
   const maxZoom = 6;
   const minZoom = 0.2;
   const scaleFactor = Math.max(Math.min(maxZoom, allNodes.zoomFactor), minZoom);
 
+  const bubbleEvent = () => {
+    const newEvent = document.createEvent('MouseEvents');
+    newEvent.initEvent('mousedown', true, false);
+    element.dispatchEvent(newEvent);
+  };
+
   const zoomed = () => {
+    bubbleEvent();
     settingZoom({
       zoom: event.transform.k / scaleFactor,
       x: event.transform.x,
@@ -64,9 +71,10 @@ export function setZooming(objectData, settingZoom, allowInteractions) {
         [0, 0],
         [width, height],
       ])
-      .filter(allowInteractions)
+      .filter(() => allowInteractions && event.type !== 'dblclick' && !(event.type === 'mousedown' && event.which === 3))
       .scaleExtent([minZoom * scaleFactor, maxZoom * scaleFactor])
       .on('zoom', zoomed)
+      .on('end', bubbleEvent)
   );
   settingZoom({
     zoom: 1 / scaleFactor,


### PR DESCRIPTION
Fixes:
- no zoom on double click
- zoom does not capture right click
- on zoom end and zoom, send a new click so that the context menu can be closed with a click