### PR TITLE
fix: adjust positions

### DIFF
--- a/src/styles/paths.less
+++ b/src/styles/paths.less
@@ -4,7 +4,7 @@
 
     .sn-org-path {
       fill: none;
-      stroke: #8c8c8c;
+      stroke: #4c4c4c;
       stroke-width: 1;
     }
     /* For css only transitions, does not work in IE11 */

--- a/src/tree/box.js
+++ b/src/tree/box.js
@@ -74,7 +74,7 @@ export default function box(
     cardHeight,
     buttonWidth,
     buttonHeight,
-    buttonMargin,
+    cardPadding,
     rootDiameter,
     tooltipWidth,
     tooltipPadding,
@@ -92,7 +92,7 @@ export default function box(
     .enter()
     .append('div')
     .attr('class', 'sn-org-root')
-    .attr('style', d => `top:${y(d) - rootDiameter - buttonMargin}px;left:${x(d) + (cardWidth - rootDiameter) / 2}px`)
+    .attr('style', d => `top:${y(d) - rootDiameter - cardPadding}px;left:${x(d) + (cardWidth - rootDiameter) / 2}px`)
     .attr('id', d => d.data.id);
 
   function getTooltipStyle(d) {
@@ -162,7 +162,7 @@ export default function box(
     .attr(
       'style',
       d =>
-        `width:${buttonWidth}px;height:${buttonHeight}px;top:${y(d) + cardHeight + buttonMargin}px;left:${x(d) +
+        `width:${buttonWidth}px;height:${buttonHeight}px;top:${y(d) + cardHeight + cardPadding}px;left:${x(d) +
           (cardWidth - buttonWidth) / 2}px;`
     )
     .attr('id', d => `${d.data.id}-expand`)
@@ -187,7 +187,7 @@ export default function box(
       .attr(
         'style',
         d =>
-          `width:${buttonWidth}px;height:${buttonHeight}px;top:${y(d) - buttonHeight - buttonMargin}px;left:${x(d) +
+          `width:${buttonWidth}px;height:${buttonHeight}px;top:${y(d) - buttonHeight - cardPadding}px;left:${x(d) +
             (cardWidth - buttonWidth) / 2}px;`
       )
       .attr('id', d => `${d.data.id}-up`)

--- a/src/tree/path.js
+++ b/src/tree/path.js
@@ -3,7 +3,7 @@ import constants from './size-constants';
 
 export function getPoints(d, topId, { depthSpacing, isVertical, x, y }) {
   // TODO: Generalize to make all directions work, currently on only ttb working
-  const { cardWidth, cardHeight, buttonHeight, cardPadding } = constants;
+  const { cardWidth, cardHeight, buttonHeight, cardPadding, buttonMargin } = constants;
   const points = [];
   const halfCard = { x: cardWidth / 2, y: cardHeight / 2 };
   const start = { x: x(d), y: y(d) };
@@ -19,8 +19,8 @@ export function getPoints(d, topId, { depthSpacing, isVertical, x, y }) {
           ? [
             { x: start.x, y: start.y + halfCard.y },
             { x: end.x - halfCard.x, y: start.y + halfCard.y },
-            { x: end.x - halfCard.x, y: end.y + cardPadding },
-            { x: end.x, y: end.y + cardPadding },
+            { x: end.x - halfCard.x, y: end.y + buttonMargin },
+            { x: end.x, y: end.y + buttonMargin },
             { x: end.x, y: end.y },
           ]
           : [

--- a/src/tree/path.js
+++ b/src/tree/path.js
@@ -3,14 +3,14 @@ import constants from './size-constants';
 
 export function getPoints(d, topId, { depthSpacing, isVertical, x, y }) {
   // TODO: Generalize to make all directions work, currently on only ttb working
-  const { cardWidth, cardHeight, buttonMargin, buttonHeight } = constants;
+  const { cardWidth, cardHeight, buttonHeight, cardPadding } = constants;
   const points = [];
   const halfCard = { x: cardWidth / 2, y: cardHeight / 2 };
   const start = { x: x(d), y: y(d) };
 
   if (d.parent && d.parent.data.id !== 'Root' && d.data.id !== topId) {
     const halfDepth = depthSpacing / 2;
-    const end = { x: x(d.parent) + halfCard.x, y: y(d.parent) + cardHeight + buttonMargin + buttonHeight };
+    const end = { x: x(d.parent) + halfCard.x, y: y(d.parent) + cardHeight + cardPadding + buttonHeight };
 
     if (haveNoChildren(d.parent.children)) {
       // to leafs
@@ -19,8 +19,8 @@ export function getPoints(d, topId, { depthSpacing, isVertical, x, y }) {
           ? [
             { x: start.x, y: start.y + halfCard.y },
             { x: end.x - halfCard.x, y: start.y + halfCard.y },
-            { x: end.x - halfCard.x, y: end.y + buttonMargin },
-            { x: end.x, y: end.y + buttonMargin },
+            { x: end.x - halfCard.x, y: end.y + cardPadding },
+            { x: end.x, y: end.y + cardPadding },
             { x: end.x, y: end.y },
           ]
           : [
@@ -43,14 +43,14 @@ export function getPoints(d, topId, { depthSpacing, isVertical, x, y }) {
         isVertical
           ? [
             { x: start.x + halfCard.x, y: start.y },
-            { x: start.x + halfCard.x, y: start.y - buttonMargin },
-            { x: end.x, y: start.y - buttonMargin },
+            { x: start.x + halfCard.x, y: start.y - cardPadding },
+            { x: end.x, y: start.y - cardPadding },
             { x: end.x, y: end.y },
           ]
           : [
             { x: start.x, y: start.y },
-            { x: start.x - buttonMargin, y: start.y },
-            { x: start.x - buttonMargin, y: end.y },
+            { x: start.x - cardPadding, y: start.y },
+            { x: start.x - cardPadding, y: end.y },
             { x: end.x, y: end.y },
           ]
       );
@@ -59,7 +59,7 @@ export function getPoints(d, topId, { depthSpacing, isVertical, x, y }) {
     // to up button or dummy root
     points.push([
       { x: start.x + halfCard.x, y: start.y },
-      { x: start.x + halfCard.x, y: start.y - buttonMargin },
+      { x: start.x + halfCard.x, y: start.y - cardPadding },
     ]);
   }
 
@@ -67,7 +67,7 @@ export function getPoints(d, topId, { depthSpacing, isVertical, x, y }) {
     // to expand button
     points.push([
       { x: start.x + halfCard.x, y: start.y + cardHeight },
-      { x: start.x + halfCard.x, y: start.y + cardHeight + buttonMargin },
+      { x: start.x + halfCard.x, y: start.y + cardHeight + cardPadding },
     ]);
   }
 

--- a/src/tree/path.spec.js
+++ b/src/tree/path.spec.js
@@ -36,17 +36,19 @@ describe('path', () => {
         },
         xActual: 0,
         yActual: 0,
-        children: [{
-          children: [{}],
-        }],
+        children: [
+          {
+            children: [{}],
+          },
+        ],
       };
       d = {
         parent,
         xActual: 300,
         yActual: cardHeight + heightMargin,
         data: {
-          id: '1'
-        }
+          id: '1',
+        },
       };
       positioning = {
         nodeSize,
@@ -59,10 +61,10 @@ describe('path', () => {
 
     it('should return points for vertical tree', () => {
       expectedPoints = [
-        { x: 376, y: 124 },
+        { x: 376, y: 120 },
         { x: 376, y: 112 },
         { x: 76, y: 112 },
-        { x: 76, y: 100 }
+        { x: 76, y: 96 },
       ];
       const points = getPoints(d, topId, positioning)[0];
       expect(points).to.deep.equal(expectedPoints);
@@ -75,7 +77,7 @@ describe('path', () => {
         { x: 400, y: 250 },
         { x: 250, y: 250 },
         { x: 250, y: 50 },
-        { x: 100, y: 50 }
+        { x: 100, y: 50 },
       ];
       const points = getPoints(d, positioning, isVertical);
       expect(points).to.deep.equal(expectedPoints);
@@ -84,11 +86,11 @@ describe('path', () => {
     it('should return points for vertical tree w only leafs', () => {
       parent.children = [{}];
       expectedPoints = [
-        { x: 300, y: 156 },
-        { x: 0, y: 156 },
-        { x: 0, y: 112 },
-        { x: 76, y: 112 },
-        { x: 76, y: 100 }
+        { x: 300, y: 152 },
+        { x: 0, y: 152 },
+        { x: 0, y: 104 },
+        { x: 76, y: 104 },
+        { x: 76, y: 96 },
       ];
       const points = getPoints(d, topId, positioning)[0];
       expect(points).to.deep.equal(expectedPoints);
@@ -103,7 +105,7 @@ describe('path', () => {
         { x: 400, y: 0 },
         { x: 250, y: 0 },
         { x: 250, y: 50 },
-        { x: 100, y: 50 }
+        { x: 100, y: 50 },
       ];
       const points = getPoints(d, positioning, isVertical);
       expect(points).to.deep.equal(expectedPoints);
@@ -112,8 +114,8 @@ describe('path', () => {
     it('should return points for a straight vertical line', () => {
       d.xActual = 0;
       expectedPoints = [
-        { x: 76, y: 124 },
-        { x: 76, y: 100 }
+        { x: 76, y: 120 },
+        { x: 76, y: 96 },
       ];
       const points = getPoints(d, topId, positioning)[0];
       expect(points).to.deep.equal(expectedPoints);
@@ -123,7 +125,7 @@ describe('path', () => {
       d.yActual = 0;
       expectedPoints = [
         { x: 400, y: 50 },
-        { x: 100, y: 50 }
+        { x: 100, y: 50 },
       ];
       const points = getPoints(d, positioning, isVertical);
       expect(points).to.deep.equal(expectedPoints);
@@ -132,8 +134,8 @@ describe('path', () => {
     it('should return points for line to up button', () => {
       topId = '1';
       expectedPoints = [
-        { x: 376, y: 124 },
-        { x: 376, y: 112 }
+        { x: 376, y: 120 },
+        { x: 376, y: 112 },
       ];
       const points = getPoints(d, topId, positioning)[0];
       expect(points).to.deep.equal(expectedPoints);
@@ -142,8 +144,8 @@ describe('path', () => {
     it('should return points for line to expand button', () => {
       d.children = [{}];
       expectedPoints = [
-        { x: 376, y: 188 },
-        { x: 376, y: 200 }
+        { x: 376, y: 184 },
+        { x: 376, y: 192 },
       ];
       const points = getPoints(d, topId, positioning)[1];
       expect(points).to.deep.equal(expectedPoints);
@@ -153,8 +155,8 @@ describe('path', () => {
       topId = 'Root';
       d.parent.data.id = 'Root';
       expectedPoints = [
-        { x: 376, y: 124 },
-        { x: 376, y: 112 }
+        { x: 376, y: 120 },
+        { x: 376, y: 112 },
       ];
       const points = getPoints(d, topId, positioning)[0];
       expect(points).to.deep.equal(expectedPoints);

--- a/src/tree/path.spec.js
+++ b/src/tree/path.spec.js
@@ -88,8 +88,8 @@ describe('path', () => {
       expectedPoints = [
         { x: 300, y: 152 },
         { x: 0, y: 152 },
-        { x: 0, y: 104 },
-        { x: 76, y: 104 },
+        { x: 0, y: 112 },
+        { x: 76, y: 112 },
         { x: 76, y: 96 },
       ];
       const points = getPoints(d, topId, positioning)[0];

--- a/src/tree/size-constants.js
+++ b/src/tree/size-constants.js
@@ -1,13 +1,15 @@
-const buttonMargin = 12;
+const cardPadding = 8;
+const buttonMargin = 16;
 const buttonHeight = 24;
 
 const constants = {
   cardWidth: 152,
   cardHeight: 64,
   widthMargin: 32,
-  heightMargin: buttonHeight + buttonMargin * 3,
-  leafMargin: 16,
+  heightMargin: buttonHeight + cardPadding * 2 + buttonMargin,
   buttonMargin,
+  leafMargin: 16,
+  cardPadding,
   buttonWidth: 48, // TODO: might need to be dynamic
   buttonHeight,
   rootDiameter: 20,


### PR DESCRIPTION
Adjusts the positions of the expand buttons and the path, making it a bit clearer to which node the expand button belongs.

Before:
![image](https://user-images.githubusercontent.com/6318307/74753052-da90ed80-526f-11ea-958a-cda7c6423f29.png)

After:
![image](https://user-images.githubusercontent.com/6318307/74753100-e977a000-526f-11ea-9775-68e54e276dea.png)
