### PR TITLE
fix: Update styling when theme is changed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ export default function supernova(env) {
           // Resolving the promise to indicate readiness for printing
           return Promise.resolve();
         });
-      }, [layout, model, translator]);
+      }, [layout, model, translator, Theme.name()]);
 
       // This one can split up. Only need to get new height/width when rect is changed
       useEffect(() => {

--- a/src/utils/__tests__/color-utils.spec.js
+++ b/src/utils/__tests__/color-utils.spec.js
@@ -1,34 +1,6 @@
-import colorUtils, { getCurrentTheme } from '../color-utils';
-import defaultValues from '../../__tests__/default-orgchart-props';
+import colorUtils from '../color-utils';
 
 describe('color-utils', () => {
-  const palette = ['color1', 'color2', 'color3'];
-  describe('resolveColor', () => {
-    it('should resolve color', () => {
-      const color = colorUtils.resolveColor('color2', palette);
-      expect(color).to.equal('color2');
-    });
-    it('should take index color from palette', () => {
-      const color = colorUtils.resolveColor({ index: 2, color: 'some' }, palette);
-      expect(color).to.equal('color3');
-    });
-    it('should resolve color from input.color', () => {
-      const color = colorUtils.resolveColor({ color: 'myColor' }, palette);
-      expect(color).to.equal('myColor');
-    });
-    it('should resolve color to none when color not defined', () => {
-      const color = colorUtils.resolveColor({ color: null }, palette);
-      expect(color).to.equal('none');
-    });
-    it('should resolve color to none when input not defined', () => {
-      const color = colorUtils.resolveColor({}, palette);
-      expect(color).to.equal('none');
-    });
-    it('should return none as default', () => {
-      const color = colorUtils.resolveColor();
-      expect(color).to.equal('none');
-    });
-  });
   describe('resolveExpression', () => {
     it('should resolve color for rgb expression', () => {
       const color = colorUtils.resolveExpression('RGB(255,255,0)');
@@ -53,27 +25,6 @@ describe('color-utils', () => {
     it('should return none for invalid expressions', () => {
       const color = colorUtils.resolveExpression('RGB(asdf)');
       expect(color).to.equal('none');
-    });
-  });
-  describe('getPalette', () => {
-    it('should return empty array as default', () => {
-      const result = colorUtils.getPalette();
-      expect(result).to.be.an('array').that.is.empty;
-    });
-    it('should return array from default properties', () => {
-      const result = colorUtils.getPalette(defaultValues.Theme);
-      expect(result).to.include.members(['none', 'color1', 'color2']);
-    });
-  });
-  describe('getCurrentTheme', () => {
-    it('should result no theme', () => {
-      const result = getCurrentTheme();
-      expect(result).to.be.undefined;
-    });
-    it('should result current theme', () => {
-      const result = getCurrentTheme(defaultValues.Theme);
-      expect(result).to.be.an('object');
-      expect(result).to.have.keys('properties');
     });
   });
 

--- a/src/utils/__tests__/styling.spec.js
+++ b/src/utils/__tests__/styling.spec.js
@@ -5,30 +5,33 @@ describe('styling', () => {
     let reference;
     const palette = ['firstColor', 'secondColor'];
     const defaultColor = '#e6e6e6';
+    const Theme = {
+      getColorPickerColor: (color) => palette[color.index] || 'none'
+    };
     beforeEach(() => {
       reference = { colorType: 'auto', colorExpression: 'pink', color: { index: 1 } };
     });
     it('should return default color', () => {
-      const result = getColor(reference, palette, defaultColor);
+      const result = getColor(reference, Theme, defaultColor);
       expect(result).to.equal(defaultColor);
     });
 
     it('should return color from expression', () => {
       reference.colorType = 'byExpression';
-      const result = getColor(reference, palette, defaultColor);
+      const result = getColor(reference, Theme, defaultColor);
       expect(result).to.equal('rgba(255,192,203,1)');
     });
 
     it('should return color from colorPicker', () => {
       reference.colorType = 'colorPicker';
-      const result = getColor(reference, palette, defaultColor);
+      const result = getColor(reference, Theme, defaultColor);
       expect(result).to.equal('secondColor');
     });
 
     it('should return default color from colorPicker', () => {
       reference.colorType = 'colorPicker';
       reference.color.index = 10;
-      const result = getColor(reference, palette, defaultColor);
+      const result = getColor(reference, Theme, defaultColor);
       expect(result).to.equal('#e6e6e6');
     });
   });

--- a/src/utils/color-utils.js
+++ b/src/utils/color-utils.js
@@ -1,13 +1,6 @@
 /* eslint-disable no-cond-assign */
 import CSSColors from './css-colors';
 
-export const getCurrentTheme = Theme => {
-  if (Theme && Theme.getCurrent) {
-    return Theme.getCurrent();
-  }
-  return undefined;
-};
-
 const colorUtils = {
   resolveExpression: input => {
     // rgb
@@ -34,23 +27,6 @@ const colorUtils = {
     }
     // invalid
     return 'none';
-  },
-  resolveColor: (input, palette) => {
-    // Resolve color from a palette. We should open Theme API from sense so we can use same functionality
-    if (typeof input !== 'undefined' && input !== null) {
-      if (input.index !== undefined && input.index !== -1 && palette[input.index]) {
-        return palette[input.index];
-      }
-      if (input.color !== undefined) {
-        return !input.color ? 'none' : input.color;
-      }
-      return typeof input === 'string' ? input : 'none';
-    }
-    return 'none';
-  },
-  getPalette: Theme => {
-    const current = getCurrentTheme(Theme);
-    return (current && current.properties.palettes.ui[0].colors) || [];
   },
   getDarkColor(color) {
     const percent = 0.5;

--- a/src/utils/styling.js
+++ b/src/utils/styling.js
@@ -1,13 +1,13 @@
 import colorUtils from './color-utils';
 
-export function getColor(reference, palette, defaultColor) {
+export function getColor(reference, Theme, defaultColor) {
   let color;
   switch (reference.colorType) {
     case 'byExpression':
       color = colorUtils.resolveExpression(reference.colorExpression);
       break;
     case 'colorPicker':
-      color = colorUtils.resolveColor(reference.color, palette);
+      color = Theme.getColorPickerColor(reference.color);
       break;
     default:
       color = defaultColor;
@@ -17,9 +17,8 @@ export function getColor(reference, palette, defaultColor) {
 
 const stylingUtils = {
   cardStyling: ({ Theme, layout }) => {
-    const palette = colorUtils.getPalette(Theme);
-    const backgroundColor = getColor(layout.style.backgroundColor, palette, '#e6e6e6');
-    const fontColor = getColor(layout.style.fontColor, palette, 'default');
+    const backgroundColor = getColor(layout.style.backgroundColor, Theme, '#e6e6e6');
+    const fontColor = getColor(layout.style.fontColor, Theme, 'default');
     const measureLabel = layout.qHyperCube.qMeasureInfo.length
       ? layout.qHyperCube.qMeasureInfo[0].qFallbackTitle
       : null;


### PR DESCRIPTION
Should we still set `layout` in `usePromise`? Feels like a bit of a stretch to redo everything when `layout` has not change