### PR TITLE
feat: auto width tooltip and restyle

### DIFF
--- a/src/styles/nodes.less
+++ b/src/styles/nodes.less
@@ -10,6 +10,7 @@
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
+    backface-visibility: hidden;
 
     &:not(.org-disable-transition) {
       transition-property: all;

--- a/src/styles/tooltip.less
+++ b/src/styles/tooltip.less
@@ -2,37 +2,58 @@
   .sn-org-tooltip {
     visibility: hidden;
     opacity: 0;
+    /* Unsupported in IE, so there we set width explicitly */
+    width: fit-content;
+
+    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+      width: 230px;
+    }
+
+    /* Position the tooltip text */
+    position: absolute;
+    z-index: 1;
+  }
+
+  /* Tooltip arrow */
+  .sn-org-tooltip::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 0%;
+    margin-left: -10px;
+    border-width: 10px;
+    border-style: solid;
+    border-color: #404040 transparent transparent transparent;
+  }
+
+  .sn-org-tooltip-visible {
+    opacity: 0.9;
+    visibility: visible;
+  }
+
+  .sn-org-tooltip-inner {
+    max-width: 240px;
+    right: 50%;
     font-family: 'QlikView Sans', sans-serif;
-    width: 240px;
-    max-height: 100px;
+    position: relative;
+
+    max-height: 150px;
     background-color: #404040;
-    color: #E6E6E6;
-    text-align: center;
-    font-size: 12px;
+    color: #e6e6e6;
+    text-align: left;
+    font-size: 13px;
     line-height: 15px;
-    padding: 5px 0;
+    padding: 10px 10px 10px 10px;
     border-radius: 6px;
 
     overflow-wrap: break-word;
     word-wrap: break-word;
     word-break: break-word;
+    overflow: hidden;
 
-    /* Position the tooltip text */
-    position: absolute;
-    z-index: 1;
-    bottom: 125%;
-    left: 50%;
-  }
-
-  /* Tooltip arrow */
-  .sn-org-tooltip::after {
-    content: "";
-    position: absolute;
-    top: 100%;
-    left: 50%;
-    margin-left: -10px;
-    border-width: 10px;
-    border-style: solid;
-    border-color: #404040 transparent transparent transparent;
+    .sn-org-tooltip-header {
+      font-weight: bold;
+      padding-bottom: 5px;
+    }
   }
 }

--- a/src/styles/tooltip.less
+++ b/src/styles/tooltip.less
@@ -3,11 +3,9 @@
     visibility: hidden;
     opacity: 0;
     /* Unsupported in IE, so there we set width explicitly */
+    width: 230px;
+    width: -moz-max-content;
     width: fit-content;
-
-    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-      width: 230px;
-    }
 
     /* Position the tooltip text */
     position: absolute;

--- a/src/tree/tooltip.js
+++ b/src/tree/tooltip.js
@@ -3,25 +3,26 @@ import constants from './size-constants';
 
 export function createTooltip(element) {
   const tooltip = select(element)
-    .selectAll('.sn-org-tooltip')
-    .data([{}])
-    .enter()
     .append('div')
     .attr('class', 'sn-org-tooltip')
     .on('mousedown', () => {
-      tooltip.html('').attr('style', 'visibility: hidden;opacity: 0;');
+      tooltip.classed('sn-org-tooltip-visible', false);
     });
   return tooltip;
 }
 
+function getLabels(label, subLabel, extraLabel, measure) {
+  return `<div class="sn-org-tooltip-inner"><div class="sn-org-tooltip-header">${label}</div>
+  ${subLabel}${extraLabel}${measure}
+  </div>`;
+}
+
 function getTooltipStyle(d, containerHeight, x, y, sel) {
-  const { cardWidth, tooltipWidth, tooltipPadding } = constants;
+  const { cardWidth, tooltipPadding } = constants;
   const halfCardWidth = cardWidth / 2;
-  const halfTooltipWidth = tooltipWidth / 2;
   const yLocation = containerHeight - (y(d) * sel.transform.zoom + sel.transform.y - tooltipPadding);
-  const xLocation =
-    x(d) * sel.transform.zoom + sel.transform.x - (halfTooltipWidth - halfCardWidth * sel.transform.zoom);
-  return `bottom:${yLocation}px;left:${xLocation}px;visibility: visible;opacity: 0.9;`;
+  const xLocation = x(d) * sel.transform.zoom + sel.transform.x + halfCardWidth * sel.transform.zoom;
+  return `bottom:${yLocation}px;left:${xLocation}px;`;
 }
 
 export function openTooltip(tooltip, d, containerHeight, cardStyling, x, y, sel) {
@@ -35,7 +36,8 @@ export function openTooltip(tooltip, d, containerHeight, cardStyling, x, y, sel)
   tooltip.timeout = setTimeout(() => {
     if (tooltip.active) {
       tooltip
-        .html(`${label}<br />${subLabel}${extraLabel}${measure}`)
+        .html(getLabels(label, subLabel, extraLabel, measure))
+        .classed('sn-org-tooltip-visible', true)
         .attr('style', () => getTooltipStyle(d, containerHeight, x, y, sel));
     }
   }, 250);
@@ -44,5 +46,5 @@ export function openTooltip(tooltip, d, containerHeight, cardStyling, x, y, sel)
 export function closeTooltip(tooltip) {
   clearTimeout(tooltip.timeout);
   tooltip.active = false;
-  tooltip.attr('style', 'visibility: hidden;opacity: 0;');
+  tooltip.classed('sn-org-tooltip-visible', false);
 }


### PR DESCRIPTION
- Updated the styles to better fit the client tooltips
- Switched to auto width, using a dummy parent element to center it
- using width: fit-content to allow overflow (setting a fixed size in IE).