### PR TITLE
feat: correct zoom on first render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,11 +17,12 @@ import {
 import properties from './object-properties';
 import data from './data';
 import ext from './extension/ext';
-import { paintTree, preRenderTree, createSnapshotData } from './tree/render';
+import { paintTree, preRenderTree, createSnapshotData, filterTree } from './tree/render';
+import position from './tree/position';
 import stylingUtils from './utils/styling';
 import treeTransform from './utils/tree-utils';
 import viewStateUtil from './utils/viewstate-utils';
-import { setZooming } from './tree/transform';
+import { setZooming, getBBoxOfNodes, getInitialZoomState } from './tree/transform';
 import autoRegister from './locale/translations';
 import './styles/tooltip.less';
 import './styles/paths.less';
@@ -177,13 +178,6 @@ export default function supernova(env) {
           const preRender = preRenderTree(element, dataTree);
           if (preRender) {
             setObjectData(preRender);
-            !expandedState &&
-              setExpandedState({
-                topId: preRender.allNodes.data.id,
-                isExpanded: true,
-                expandedChildren: [],
-                useTransitions: false,
-              });
           }
         }
       }, [element, dataTree]);
@@ -201,17 +195,48 @@ export default function supernova(env) {
             element,
           });
         }
-      }, [expandedState, objectData, selectionState]);
+      }, [expandedState, selectionState]);
 
       useEffect(() => {
         if (objectData && layout.navigationMode === 'free') {
           const viewState = viewStateUtil.getViewState(opts, layout);
+          const newExpandedState = expandedState || {
+            topId: objectData.allNodes.data.id,
+            isExpanded: true,
+            expandedChildren: [],
+            useTransitions: false,
+          };
+          const renderNodes = filterTree(newExpandedState, objectData.allNodes);
+          renderNodes.forEach(node => {
+            if (!node.xActual || !node.yActual) {
+              objectData.positioning.x(node);
+              objectData.positioning.y(node);
+            }
+          });
+          const bBox = getBBoxOfNodes(renderNodes);
+          const initialZoomState = getInitialZoomState(bBox, element);
+          objectData.positioning = position('ttb', element, initialZoomState);
           setZooming({
             objectData,
             setTransform,
             transformState: (viewState && viewState.transform) || {},
             selectionsAndTransform,
+            initialZoomState,
           });
+          if (!expandedState) {
+            setExpandedState(newExpandedState);
+          } else {
+            paintTree({
+              objectData,
+              expandedState,
+              styling,
+              setStateCallback,
+              selectionsAndTransform,
+              selectionState,
+              useTransitions: expandedState.useTransitions,
+              element,
+            });
+          }
         }
       }, [objectData]);
 

--- a/src/tree/__tests__/position.spec.js
+++ b/src/tree/__tests__/position.spec.js
@@ -18,17 +18,24 @@ describe('position', () => {
     const depthSpacing = 124;
     let axis;
     let d;
+    let initialZoomState;
     beforeEach(() => {
       axis = 'xActual';
       d = JSON.parse(JSON.stringify(defaultValues.nodes));
+      initialZoomState = { initialX: 0, initialY: 0 };
     });
-    it('should return yActual for leaf node', () => {
-      const yActual = depthTranslation(d, depthSpacing, axis);
+    it('should return yActual for node with initial offset', () => {
+      initialZoomState.initialY = 100;
+      const yActual = depthTranslation(d, depthSpacing, axis, initialZoomState);
+      expect(yActual).to.equal(224);
+    });
+    it('should return yActual for node', () => {
+      const yActual = depthTranslation(d, depthSpacing, axis, initialZoomState);
       expect(yActual).to.equal(124);
     });
     it('should return yActual for leaf node', () => {
       d.parent.children = undefined;
-      const yActual = depthTranslation(d, depthSpacing, axis);
+      const yActual = depthTranslation(d, depthSpacing, axis, initialZoomState);
       expect(yActual).to.equal(204);
     });
   });
@@ -40,13 +47,30 @@ describe('position', () => {
     };
     let axis;
     let d;
+    let initialZoomState;
     beforeEach(() => {
       axis = 'xActual';
       d = JSON.parse(JSON.stringify(defaultValues.nodes));
+      initialZoomState = { initialX: 100, initialY: 0 };
     });
-    it('should return xActual for leaf node', () => {
-      const xActual = widthTranslation(d, widthSpacing, element, axis);
+    it('should return xActual for node', () => {
+      const xActual = widthTranslation(d, widthSpacing, element, axis, initialZoomState);
       expect(xActual).to.equal(124);
+    });
+    it('should return xActual for node with root parent and initialsZoom', () => {
+      d.parent.data.id = 'Root';
+      const xActual = widthTranslation(d, widthSpacing, element, axis, initialZoomState);
+      expect(xActual).to.equal(224);
+    });
+    it('should return xActual for node with root parent and no initialsZoom', () => {
+      d.parent.data.id = 'Root';
+      const xActual = widthTranslation(d, widthSpacing, element, axis, {});
+      expect(xActual).to.equal(124);
+    });
+    it('should return xActual for parent node', () => {
+      d = {};
+      const xActual = widthTranslation(d, widthSpacing, element, axis, initialZoomState);
+      expect(xActual).to.equal(100);
     });
   });
 });

--- a/src/tree/__tests__/transform.spec.js
+++ b/src/tree/__tests__/transform.spec.js
@@ -1,4 +1,4 @@
-import { getBBoxOfNodes, getTranslations } from '../transform';
+import { getBBoxOfNodes, getTranslations, getInitialZoomState } from '../transform';
 
 describe('transform', () => {
   describe('getBBoxOfNodes', () => {
@@ -56,6 +56,27 @@ describe('transform', () => {
         };
         expect(translatoions).to.deep.equal(expected);
       });
+    });
+  });
+
+  describe('getInitialZoomState', () => {
+    let element;
+    let bBox;
+    beforeEach(() => {
+      element = { clientWidth: 1000, clientHeight: 1000 };
+      bBox = { width: 1000, height: 1000, x: 0, y: 0 };
+    });
+
+    it('should zoom in x direction', () => {
+      bBox.width = 1936;
+      const result = getInitialZoomState(bBox, element);
+      expect(result).to.eql({ initialX: 32, initialY: 500, initialZoom: 2 });
+    });
+
+    it('should zoom in y direction', () => {
+      bBox.height = 1936;
+      const result = getInitialZoomState(bBox, element);
+      expect(result).to.eql({ initialX: 500, initialY: 32, initialZoom: 2 });
     });
   });
 });

--- a/src/tree/path.js
+++ b/src/tree/path.js
@@ -6,7 +6,7 @@ export function getPoints(d, topId, { depthSpacing, isVertical, x, y }) {
   const { cardWidth, cardHeight, buttonHeight, cardPadding, buttonMargin } = constants;
   const points = [];
   const halfCard = { x: cardWidth / 2, y: cardHeight / 2 };
-  const start = { x: x(d), y: y(d) };
+  const start = { x: d.xActual, y: d.yActual };
 
   if (d.parent && d.parent.data.id !== 'Root' && d.data.id !== topId) {
     const halfDepth = depthSpacing / 2;

--- a/src/tree/position.js
+++ b/src/tree/position.js
@@ -3,18 +3,22 @@ import constants from './size-constants';
 
 export const widthTranslation = (d, widthSpacing, element, axis, initialZoomState) => {
   const { buttonMargin } = constants;
+  const initialX = (initialZoomState && initialZoomState.initialX) || 0;
 
   if (d.parent) {
     if (!d.parent[axis]) {
       d.parent[axis] = widthTranslation(d.parent, widthSpacing, element, axis);
     }
-    d[axis] =
-      d.parent.data.id !== 'Root' && haveNoChildren(d.parent.children)
+    if (d.parent.data.id === 'Root') {
+      d[axis] = d.parent[axis] + (d.data.childNumber - (d.parent.children.length - 1) / 2) * widthSpacing + initialX;
+    } else {
+      d[axis] = haveNoChildren(d.parent.children)
         ? d.parent[axis] + buttonMargin
         : d.parent[axis] + (d.data.childNumber - (d.parent.children.length - 1) / 2) * widthSpacing;
+    }
   } else {
     // In case of zoom mode we need to have the tree moved to the right from the start
-    d[axis] = (initialZoomState && initialZoomState.x) || 0;
+    d[axis] = initialX;
   }
 
   return d[axis];
@@ -22,15 +26,12 @@ export const widthTranslation = (d, widthSpacing, element, axis, initialZoomStat
 
 export const depthTranslation = (d, depthSpacing, axis, initialZoomState) => {
   const { cardHeight, leafMargin } = constants;
+  const initialY = (initialZoomState && initialZoomState.initialY) || 0;
 
   if (d.parent && d.parent.data.id !== 'Root' && haveNoChildren(d.parent.children)) {
-    d[axis] =
-      d.parent.y +
-      depthSpacing +
-      d.data.childNumber * (cardHeight + leafMargin) +
-      ((initialZoomState && initialZoomState.y) || 0);
+    d[axis] = d.parent.y + depthSpacing + d.data.childNumber * (cardHeight + leafMargin) + initialY;
   } else {
-    d[axis] = d.y + ((initialZoomState && initialZoomState.y) || 0);
+    d[axis] = d.y + initialY;
   }
   return d[axis];
 };

--- a/src/tree/position.js
+++ b/src/tree/position.js
@@ -24,7 +24,11 @@ export const depthTranslation = (d, depthSpacing, axis, initialZoomState) => {
   const { cardHeight, leafMargin } = constants;
 
   if (d.parent && d.parent.data.id !== 'Root' && haveNoChildren(d.parent.children)) {
-    d[axis] = d.parent.y + depthSpacing + d.data.childNumber * (cardHeight + leafMargin);
+    d[axis] =
+      d.parent.y +
+      depthSpacing +
+      d.data.childNumber * (cardHeight + leafMargin) +
+      ((initialZoomState && initialZoomState.y) || 0);
   } else {
     d[axis] = d.y + ((initialZoomState && initialZoomState.y) || 0);
   }

--- a/src/tree/position.js
+++ b/src/tree/position.js
@@ -1,7 +1,7 @@
 import { haveNoChildren } from '../utils/tree-utils';
 import constants from './size-constants';
 
-export default function position(orientation, element) {
+export default function position(orientation, element, initialZoomState) {
   const { widthMargin, heightMargin, cardWidth, cardHeight, leafMargin, buttonMargin } = constants;
   let widthSpacing;
   let depthSpacing;
@@ -17,16 +17,10 @@ export default function position(orientation, element) {
           ? d.parent[axis] + buttonMargin
           : d.parent[axis] + (d.data.childNumber - (d.parent.children.length - 1) / 2) * widthSpacing;
     } else if (!d.children) {
-      d[axis] = (element.clientWidth - cardWidth) / 2;
-      d.zoomFactor = 1;
+      d[axis] = initialZoomState.x || 0;
     } else {
       // In case of zoom mode we need to have the tree moved to the right from the start
-      const neededWidth = (cardWidth + widthMargin) * d.children.length - widthMargin;
-      const zoomFactor = neededWidth / element.clientWidth;
-      d[axis] = (element.clientWidth / 2) * zoomFactor - cardWidth / 2;
-      if (!d.zoomFactor) {
-        d.zoomFactor = zoomFactor;
-      }
+      d[axis] = initialZoomState.x || 0;
     }
 
     return d[axis];
@@ -36,7 +30,7 @@ export default function position(orientation, element) {
     if (d.parent && d.parent.data.id !== 'Root' && haveNoChildren(d.parent.children)) {
       d[axis] = d.parent[axis] + depthSpacing + d.data.childNumber * (cardHeight + leafMargin);
     } else {
-      d[axis] = d.y;
+      d[axis] = d.y + (initialZoomState.y || 0);
     }
     return d[axis];
   };

--- a/src/tree/position.js
+++ b/src/tree/position.js
@@ -16,8 +16,6 @@ export default function position(orientation, element, initialZoomState) {
         d.parent.data.id !== 'Root' && haveNoChildren(d.parent.children)
           ? d.parent[axis] + buttonMargin
           : d.parent[axis] + (d.data.childNumber - (d.parent.children.length - 1) / 2) * widthSpacing;
-    } else if (!d.children) {
-      d[axis] = initialZoomState.x || 0;
     } else {
       // In case of zoom mode we need to have the tree moved to the right from the start
       d[axis] = initialZoomState.x || 0;

--- a/src/tree/position.js
+++ b/src/tree/position.js
@@ -1,8 +1,8 @@
 import { haveNoChildren } from '../utils/tree-utils';
 import constants from './size-constants';
 
-export const widthTranslation = (d, widthSpacing, element, axis) => {
-  const { widthMargin, cardWidth, buttonMargin } = constants;
+export const widthTranslation = (d, widthSpacing, element, axis, initialZoomState) => {
+  const { buttonMargin } = constants;
 
   if (d.parent) {
     if (!d.parent[axis]) {
@@ -12,34 +12,26 @@ export const widthTranslation = (d, widthSpacing, element, axis) => {
       d.parent.data.id !== 'Root' && haveNoChildren(d.parent.children)
         ? d.parent[axis] + buttonMargin
         : d.parent[axis] + (d.data.childNumber - (d.parent.children.length - 1) / 2) * widthSpacing;
-  } else if (!d.children) {
-    d[axis] = (element.clientWidth - cardWidth) / 2;
-    d.zoomFactor = 1;
   } else {
     // In case of zoom mode we need to have the tree moved to the right from the start
-    const neededWidth = (cardWidth + widthMargin) * d.children.length - widthMargin;
-    const zoomFactor = neededWidth / element.clientWidth;
-    d[axis] = (element.clientWidth / 2) * zoomFactor - cardWidth / 2;
-    if (!d.zoomFactor) {
-      d.zoomFactor = zoomFactor;
-    }
+    d[axis] = (initialZoomState && initialZoomState.x) || 0;
   }
 
   return d[axis];
 };
 
-export const depthTranslation = (d, depthSpacing, axis) => {
+export const depthTranslation = (d, depthSpacing, axis, initialZoomState) => {
   const { cardHeight, leafMargin } = constants;
 
   if (d.parent && d.parent.data.id !== 'Root' && haveNoChildren(d.parent.children)) {
     d[axis] = d.parent.y + depthSpacing + d.data.childNumber * (cardHeight + leafMargin);
   } else {
-    d[axis] = d.y;
+    d[axis] = d.y + ((initialZoomState && initialZoomState.y) || 0);
   }
   return d[axis];
 };
 
-export default function position(orientation, element) {
+export default function position(orientation, element, initialZoomState) {
   const { widthMargin, heightMargin, cardWidth, cardHeight } = constants;
   let widthSpacing;
   let depthSpacing;
@@ -52,8 +44,8 @@ export default function position(orientation, element) {
       orientations = {
         depthSpacing,
         isVertical: true,
-        x: d => widthTranslation(d, widthSpacing, element, 'xActual'),
-        y: d => depthTranslation(d, depthSpacing, 'yActual'),
+        x: d => widthTranslation(d, widthSpacing, element, 'xActual', initialZoomState),
+        y: d => depthTranslation(d, depthSpacing, 'yActual', initialZoomState),
       };
       break;
     // case 'btt':

--- a/src/tree/render.js
+++ b/src/tree/render.js
@@ -114,7 +114,7 @@ export const getSize = ({ error, warn }, element) => {
 export function preRenderTree(element, dataTree) {
   element.innerHTML = '';
   element.className = 'sn-org-chart';
-  const positioning = position('ttb', element);
+  const positioning = position('ttb', element, {});
   const { width, height } = getSize(dataTree, element);
 
   const zoomWrapper = select(element)

--- a/src/tree/size-constants.js
+++ b/src/tree/size-constants.js
@@ -16,6 +16,8 @@ const constants = {
   r: 4,
   tooltipWidth: 240,
   tooltipPadding: 15,
+  maxZoom: 6,
+  minZoom: 0.2,
 };
 
 export default constants;

--- a/src/tree/transform.js
+++ b/src/tree/transform.js
@@ -34,15 +34,15 @@ export const getInitialZoomState = (bBox, element) => {
   if (xZoom > yZoom) {
     // Zooming for x direction
     return {
-      x: -bBox.x + widthMargin * xZoom,
-      y: -bBox.y,
+      initialX: -bBox.x + widthMargin * xZoom,
+      initialY: -bBox.y + (clientHeight * xZoom - height) / 2,
       initialZoom: xZoom,
     };
   }
   // Zooming for y direction
   return {
-    x: -bBox.x + widthMargin * yZoom,
-    y: cardHeight * yZoom,
+    initialX: -bBox.x + (clientWidth * yZoom - width) / 2,
+    initialY: cardHeight * yZoom,
     initialZoom: yZoom,
   };
 };

--- a/src/tree/transform.js
+++ b/src/tree/transform.js
@@ -27,14 +27,14 @@ export const getInitialZoomState = (bBox, element) => {
   const { widthMargin, cardHeight, minZoom, maxZoom } = constants;
   const { width, height } = bBox;
   const { clientHeight, clientWidth } = element;
-  const calcWidth = clientWidth - 2 * widthMargin;
-  const calcHeight = clientHeight - cardHeight;
-  const xZoom = Math.max(Math.min(width / calcWidth, maxZoom), minZoom);
-  const yZoom = Math.max(Math.min(height / calcHeight, maxZoom), minZoom);
+  const calcWidth = width + 2 * widthMargin;
+  const calcHeight = height + cardHeight;
+  const xZoom = Math.max(Math.min(calcWidth / clientWidth, maxZoom), minZoom);
+  const yZoom = Math.max(Math.min(calcHeight / clientHeight, maxZoom), minZoom);
   if (xZoom > yZoom) {
     // Zooming for x direction
     return {
-      initialX: -bBox.x + widthMargin * xZoom,
+      initialX: -bBox.x + widthMargin,
       initialY: -bBox.y + (clientHeight * xZoom - height) / 2,
       initialZoom: xZoom,
     };
@@ -42,7 +42,7 @@ export const getInitialZoomState = (bBox, element) => {
   // Zooming for y direction
   return {
     initialX: -bBox.x + (clientWidth * yZoom - width) / 2,
-    initialY: cardHeight * yZoom,
+    initialY: cardHeight / 2,
     initialZoom: yZoom,
   };
 };


### PR DESCRIPTION
So I looked a bit more into our zooming (mostly because we don't account for the height at the moment). This would also make it possible to get a Home button in by re-rendering everything. What happens:

1. We get new objectData
2. Based on expanded state we filter the tree to get the nodes we want to render
3. bBox of these nodes is determined
4. Calculations for position of the nodes and initial zooming
5. Replace positioning on objectData
6. Setting a new expanded state (if we did not have any)
7. Paint the tree (also done when setting expanded state)

It could definitely use a brush-up before we even think of merging this, but let me know what you think about it. 

Also I haven't been able to get the chart to render in the center of the element. So it will now locate in the top left corner from the start