### PR TITLE
fix: correct topId Path

### DIFF
--- a/src/tree/__tests__/path.spec.js
+++ b/src/tree/__tests__/path.spec.js
@@ -131,7 +131,7 @@ describe('path', () => {
       expect(points).to.deep.equal(expectedPoints);
     });
 
-    it('should return points for line to up button', () => {
+    it.skip('should return points for line to up button', () => {
       topId = '1';
       expectedPoints = [
         { x: 376, y: 120 },

--- a/src/tree/path.js
+++ b/src/tree/path.js
@@ -8,7 +8,8 @@ export function getPoints(d, topId, { depthSpacing, isVertical, x, y }) {
   const halfCard = { x: cardWidth / 2, y: cardHeight / 2 };
   const start = { x: x(d), y: y(d) };
 
-  if (d.parent && d.parent.data.id !== 'Root' && d.data.id !== topId) {
+  // TODO: fix so auto mode does not get a path to parent not showing
+  if (d.parent && d.parent.data.id !== 'Root') {
     const halfDepth = depthSpacing / 2;
     const end = { x: x(d.parent) + halfCard.x, y: y(d.parent) + cardHeight + cardPadding + buttonHeight };
 


### PR DESCRIPTION
Need to check what mode we are in inside `path` when we are putting that mode back in.