### PR TITLE
fix: reset expandedState when topId is not included

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ export default function supernova(env) {
           const preRender = preRenderTree(element, dataTree);
           if (preRender) {
             setObjectData(preRender);
-            !expandedState &&
+            (!expandedState || !preRender.allNodes.descendants().find(node => node.data.id === expandedState.topId)) &&
               setExpandedState({
                 topId: preRender.allNodes.data.id,
                 isExpanded: true,


### PR DESCRIPTION
This almost solves the problem. Question is if it is enough.
It will reset `expandedState` when `topId` is not in the data. But if selecting only the `topId` (and some of its children), it wont change the `expandedState`. So maybe a bit confusing when reseting the selection to have the same expanded nodes as before in this case but not in others.

If we want to do this thoroughly we basically need to run `filterTree` here