### PR TITLE
feat: add version to qext file

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "start": "nebula serve --type sn-org-chart",
     "test:unit": "aw -c aw.config.js",
     "test:integration": "aw puppet --glob 'test/integration/**/*.spec.js' --chrome.headless true --chrome.slowMo 10",
-    "prepublishOnly": "rm -rf dist && npm run build"
+    "prepublishOnly": "rm -rf dist && npm run build",
+    "version": "node ./scripts/version-qext.js && git add -A"
   },
   "husky": {
     "hooks": {

--- a/scripts/version-qext.js
+++ b/scripts/version-qext.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+
+const fileName = './assets/sn-org-chart.qext';
+const content = fs.readFileSync(fileName, 'utf-8');
+const parsedContent = JSON.parse(content);
+parsedContent.version = process.env.npm_package_version;
+fs.writeFileSync(fileName, JSON.stringify(parsedContent, null, 2));


### PR DESCRIPTION
This adds/bumps the version number in the qext file. Version number is necessary when upgrading sense client, otherwise the extension won't be present after the upgrade.

We should check if a version is necessary both on the old and the new extension and if we need some patches to be created, but this is a first step